### PR TITLE
ci: add fixture-driven Linux integration coverage

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,0 +1,76 @@
+name: Linux Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linux-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Ubuntu 24.04 / Python 3.12
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install test dependencies
+        run: python -m pip install -e ".[dev,gui]"
+
+      - name: Run unit tests
+        run: python -m pytest -m "not integration" --strict-markers -q
+
+      - name: Run fixture integration tests
+        run: python -m pytest tests/integration --strict-markers -q
+
+      - name: Verify installed CLI and per-user logging
+        shell: bash
+        env:
+          HOME: ${{ runner.temp }}/riplex-home
+          XDG_STATE_HOME: ${{ runner.temp }}/riplex-state
+          RIPLEX_NO_UPDATE_CHECK: "1"
+          TMPDIR: /tmp
+        run: |
+          set -euo pipefail
+
+          riplex --version
+          rm -rf "$HOME" "$XDG_STATE_HOME"
+          python -c 'import os; from riplex.config import save_config; save_config(output_root=os.path.join(os.environ["RUNNER_TEMP"], "output"))'
+
+          log_path="$(python -c 'from riplex.log_path import get_cli_log_path; print(get_cli_log_path())')"
+          case "$log_path" in
+            "$XDG_STATE_HOME"/*) ;;
+            *) echo "CLI log escaped XDG_STATE_HOME: $log_path"; exit 1 ;;
+          esac
+          test ! -e "$log_path"
+
+          sudo rm -rf /tmp/riplex
+          sudo install -d -o root -g root -m 0700 /tmp/riplex
+
+          missing_folder="$RUNNER_TEMP/does-not-exist"
+          set +e
+          output="$(riplex organize "$missing_folder" --auto 2>&1)"
+          status=$?
+          set -e
+
+          printf '%s\n' "$output"
+          test "$status" -eq 1
+          grep -F "Error: not a directory: $missing_folder" <<< "$output"
+          grep -F "Debug log: $log_path" <<< "$output"
+          test -f "$log_path"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,11 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Added
+
+- **Linux integration CI.** Added an Ubuntu 24.04 workflow that runs the unit
+	suite, all offline fixture-driven CLI and GUI flows, and an installed-CLI
+	logging smoke test without accessing an optical drive or performing a rip.
+
 ### Fixed
 
 - **Release-note publishing.** Upgraded `softprops/action-gh-release` to its
   supported Node 24 release so annotated-tag notes are prepended to GitHub's
   generated changes on future releases.
+- **CLI log permissions.** CLI debug logs now use the current user's platform
+	log directory instead of a shared temporary directory, avoiding failures
+	caused by a root-owned or other-user-owned `/tmp/riplex` directory on Linux.
+	Updated the CLI guide and reference with the new locations.
 
 ## v1.1.0 — 2026-08-29
 

--- a/docs/cli-guide/organize.md
+++ b/docs/cli-guide/organize.md
@@ -131,7 +131,13 @@ Duplicate MKV files (same content ripped from different playlists) are automatic
 
 ## Debug logging
 
-Every `organize` run writes detailed debug logs to the OS temp directory. Add `--verbose` to also print debug output to stderr:
+Every `organize` run writes detailed debug logs to the current user's log directory:
+
+- **Windows:** `%LOCALAPPDATA%\riplex\riplex\Logs\riplex.log`
+- **macOS:** `~/Library/Logs/riplex/riplex.log`
+- **Linux:** `~/.local/state/riplex/log/riplex.log`
+
+The CLI prints the exact path at startup. Add `--verbose` to also print debug output to stderr:
 
 ```bash
 riplex organize path/to/rips/MovieTitle --year 2023 --verbose

--- a/docs/cli-guide/workflow.md
+++ b/docs/cli-guide/workflow.md
@@ -116,4 +116,4 @@ Files are moved (and split if needed) into Plex folder structure. Each file gets
 - **Unmatched files**: Use `--unmatched extras` to route remaining files to the `Other/` extras folder
 - **Wrong release region**: Use `--release uk` or `--release 2` to pick a different dvdcompare release
 - **Re-organize**: Use `--force` to re-process files that were already tagged
-- **Debug**: Check `%TEMP%\riplex\riplex.log` or add `--verbose` for stderr output
+- **Debug**: Check the `Debug log:` path printed at startup or add `--verbose` for stderr output

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -22,6 +22,22 @@ pytest -m integration
 pytest -m "not integration"
 ```
 
+## Linux CI
+
+`.github/workflows/test-linux.yml` runs on an Ubuntu 24.04 GitHub-hosted VM for
+pull requests, pushes to `main`, and manual dispatches. It uses Python 3.12 and
+runs three checks:
+
+1. Unit tests with the integration marker excluded.
+2. Every offline fixture-driven CLI and GUI integration test.
+3. The installed `riplex` entry point with a root-owned `/tmp/riplex`
+  directory, proving CLI startup and per-user logging do not depend on a
+  writable shared temporary directory.
+
+The workflow does not access an optical drive, invoke a real rip, or call TMDb
+or dvdcompare. The integration harness supplies committed scenarios and mocks
+those external boundaries.
+
 ## GUI integration tests
 
 The integration suite builds a real `RiplexApp` on a fake page and clicks

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ Complete reference for all riplex subcommands and their options.
 
 - **Interactive by default**: When stdin is a terminal, `organize` and `rip` present numbered lists for ambiguous TMDb matches, dvdcompare release selection, and title confirmation. Pass `--auto` to skip all interactive prompts and use best-guess defaults. Non-TTY environments (piped input, cron jobs) are automatically non-interactive.
 - **Dry-run by default**: Both `organize` and `rip` preview changes without acting. Add `--execute` to apply.
-- **Logging**: Every `organize` run writes debug logs to the OS temp directory. Add `--verbose` for stderr output.
+- **Logging**: The `orchestrate`, `rip`, `organize`, and `lookup` commands write to the current user's platform log directory and print the exact path at startup. Add `--verbose` for stderr output.
 - **Caching**: dvdcompare responses are cached for 30 days, TMDb for 7 days. Use `--no-cache` to bypass.
 
 ## `orchestrate`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,6 @@ local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integration: offline fixture-driven CLI and GUI flow tests",
+]

--- a/src/riplex/log_path.py
+++ b/src/riplex/log_path.py
@@ -1,0 +1,12 @@
+"""Shared paths for riplex log files."""
+
+from pathlib import Path
+
+from platformdirs import user_log_dir
+
+_APP_NAME = "riplex"
+
+
+def get_cli_log_path() -> Path:
+    """Return the current user's CLI debug-log path."""
+    return Path(user_log_dir(_APP_NAME)) / "riplex.log"

--- a/src/riplex/snapshot.py
+++ b/src/riplex/snapshot.py
@@ -16,6 +16,7 @@ import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
+from riplex.log_path import get_cli_log_path
 from riplex.models import ScannedDisc, ScannedFile
 from riplex.scanner import scan_folder
 
@@ -70,14 +71,13 @@ def get_debug_dir(output_dir: Path) -> Path:
     return debug_dir
 
 
-def copy_debug_log(debug_dir: Path) -> Path | None:
-    """Copy the current session's ``riplex.log`` into *debug_dir*.
+def copy_debug_log(debug_dir: Path, source_log: Path | None = None) -> Path | None:
+    """Copy the current session log into *debug_dir* as ``riplex.log``.
 
-    Returns the destination path, or ``None`` if the log wasn't found.
+    *source_log* defaults to the CLI log. Returns the destination path, or
+    ``None`` if the source log wasn't found.
     """
-    import tempfile
-
-    log_src = Path(tempfile.gettempdir()) / "riplex" / "riplex.log"
+    log_src = source_log if source_log is not None else get_cli_log_path()
     if not log_src.exists():
         log.debug("No debug log found at %s", log_src)
         return None

--- a/src/riplex_app/screens/progress.py
+++ b/src/riplex_app/screens/progress.py
@@ -9,6 +9,7 @@ import flet as ft
 
 from riplex.disc.makemkv import run_rip, RipProgress, RipResult
 from riplex.snapshot import copy_debug_log, get_debug_dir, save_rip_snapshot
+from riplex_app.crash_dump import get_log_path
 from riplex_app.keep_awake import keep_awake
 
 log = logging.getLogger(__name__)
@@ -276,7 +277,7 @@ class ProgressScreen:
                 ripped_titles=[r.title_index for r in results if r.success],
                 phase="complete",
             )
-            copy_debug_log(debug_dir)
+            copy_debug_log(debug_dir, get_log_path())
             self.app.state["debug_dir"] = str(debug_dir)
             log.info("Wrote debug snapshots to %s", debug_dir)
         except Exception as exc:

--- a/src/riplex_cli/formatting.py
+++ b/src/riplex_cli/formatting.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import logging
 import random
 import sys
-import tempfile
 import time
 from pathlib import Path
 from typing import Callable
 
-
-LOG_DIR = Path(tempfile.gettempdir()) / "riplex"
+from riplex.log_path import get_cli_log_path
 
 
 _BAR_STYLES = [
@@ -63,13 +61,13 @@ def execute_hint(subcommand: str) -> str:
 def setup_logging(verbose: bool = False) -> Path:
     """Configure file-based debug logging for the entire package.
 
-    Always writes DEBUG-level output to a log file in the temp directory.
+    Always writes DEBUG-level output to the current user's log directory.
     When *verbose* is True, also prints DEBUG messages to stderr.
 
     Returns the path to the log file.
     """
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
-    log_file = LOG_DIR / "riplex.log"
+    log_file = get_cli_log_path()
+    log_file.parent.mkdir(parents=True, exist_ok=True)
 
     root = logging.getLogger("riplex")
     root.setLevel(logging.DEBUG)

--- a/tests/integration/test_flow_welcome.py
+++ b/tests/integration/test_flow_welcome.py
@@ -20,6 +20,17 @@ def test_welcome_builds_without_crash(gui):
     assert d.has_text("Organize Rips")
 
 
+def test_harness_overrides_welcome_config_alias(gui, monkeypatch):
+    from riplex_app.screens import welcome as welcome_mod
+
+    monkeypatch.setattr(welcome_mod, "load_config", lambda: {})
+    d = gui("the-matrix-1999")
+
+    d.click("Organize Rips")
+
+    assert d.state["workflow"] == "organize"
+
+
 def test_welcome_rip_button_starts_orchestrate(gui):
     d = gui("the-matrix-1999")
 

--- a/tests/support/provider_mocks.py
+++ b/tests/support/provider_mocks.py
@@ -133,6 +133,7 @@ def _install_config(monkeypatch, config: dict | None) -> None:
     try:
         import riplex_app.screens.welcome as welcome_mod
 
+        monkeypatch.setattr(welcome_mod, "load_config", lambda: dict(cfg))
         monkeypatch.setattr(welcome_mod, "find_makemkvcon", lambda: Path("makemkvcon"))
         monkeypatch.setattr(welcome_mod, "find_ffprobe", lambda: Path("ffprobe"))
         monkeypatch.setattr(welcome_mod, "find_mkvmerge", lambda: Path("mkvmerge"), raising=False)

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -455,14 +455,15 @@ class TestBuildExecuteCommand:
         result = _build_execute_command()
         assert result.count("--execute") == 1
 
-    def test_strips_exe_path(self, monkeypatch):
+    def test_strips_exe_path(self, monkeypatch, tmp_path):
+        executable = tmp_path / "riplex.exe"
         monkeypatch.setattr("sys.argv", [
-            "C:\\Users\\me\\AppData\\Local\\Programs\\Python\\Python314\\Scripts\\riplex.exe",
+            str(executable),
             "organize", "folder",
         ])
         result = _build_execute_command()
         assert result.startswith("riplex ")
-        assert "C:\\Users" not in result
+        assert str(tmp_path) not in result
 
 
 class TestDryRunBanner:

--- a/tests/test_log_path.py
+++ b/tests/test_log_path.py
@@ -1,0 +1,33 @@
+"""Tests for shared log-path helpers."""
+
+import logging
+from pathlib import Path
+
+
+def test_cli_log_path_uses_user_log_directory(tmp_path, monkeypatch):
+    from riplex.log_path import get_cli_log_path
+
+    monkeypatch.setattr(
+        "riplex.log_path.user_log_dir", lambda app_name: str(tmp_path)
+    )
+
+    assert get_cli_log_path() == Path(tmp_path) / "riplex.log"
+
+
+def test_setup_logging_creates_user_log_file(tmp_path, monkeypatch):
+    from riplex_cli.formatting import setup_logging
+
+    log_file = tmp_path / "logs" / "riplex.log"
+    monkeypatch.setattr(
+        "riplex_cli.formatting.get_cli_log_path", lambda: log_file
+    )
+
+    logger = logging.getLogger("riplex")
+    existing_handlers = set(logger.handlers)
+    try:
+        assert setup_logging() == log_file
+        assert log_file.exists()
+    finally:
+        for handler in set(logger.handlers) - existing_handlers:
+            logger.removeHandler(handler)
+            handler.close()

--- a/tests/test_makemkv.py
+++ b/tests/test_makemkv.py
@@ -216,6 +216,26 @@ class TestDriveListRaisesOnFatal:
             assert mk.drive_list() == []
 
 
+class TestDriveListTimeout:
+    def test_uses_configured_timeout(self, tmp_path):
+        from riplex.disc.makemkv import MakeMKV
+
+        fake_exe = tmp_path / "makemkvcon.exe"
+        fake_exe.write_text("")
+        mk = MakeMKV(fake_exe)
+
+        completed = MagicMock(stdout="", stderr="")
+        with (
+            patch("riplex.config.get_makemkv_list_timeout", return_value=300),
+            patch(
+                "riplex.disc.makemkv.subprocess.run", return_value=completed
+            ) as run_mock,
+        ):
+            mk.drive_list()
+
+        assert run_mock.call_args.kwargs["timeout"] == 300
+
+
 class TestMakemkvPreflight:
     def test_no_executable_found(self):
         with patch("riplex.disc.makemkv.find_makemkvcon", return_value=None):

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -110,6 +110,26 @@ def test_auto_eject_failure_is_non_fatal(monkeypatch):
     assert any("Auto-eject failed" in getattr(c, "value", "") for c in screen.log.controls)
 
 
+def test_snapshot_copies_gui_log(monkeypatch, tmp_path):
+    debug_dir = tmp_path / "_riplex"
+    gui_log = tmp_path / "logs" / "riplex_app.log"
+    copied: list[tuple] = []
+    app = _App({"output_dir": str(tmp_path / "Disc 1")})
+
+    monkeypatch.setattr(progress_mod, "get_debug_dir", lambda _path: debug_dir)
+    monkeypatch.setattr(progress_mod, "save_rip_snapshot", lambda *a, **k: None)
+    monkeypatch.setattr(progress_mod, "get_log_path", lambda: gui_log)
+    monkeypatch.setattr(
+        progress_mod,
+        "copy_debug_log",
+        lambda *args: copied.append(args),
+    )
+
+    ProgressScreen(app)._write_snapshots([])
+
+    assert copied == [(debug_dir, gui_log)]
+
+
 # ---------------------------------------------------------------------------
 # Cancel behaviour — a cancelled rip returns to the CURRENT disc, not the next
 # ---------------------------------------------------------------------------

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -257,15 +257,11 @@ class TestGetDebugDir:
 
 class TestCopyDebugLog:
     def test_copies_existing_log(self, tmp_path, monkeypatch):
-        # Create a fake log file
-        fake_tmp = tmp_path / "tmp"
-        fake_tmp.mkdir()
-        log_dir = fake_tmp / "riplex"
-        log_dir.mkdir()
-        log_file = log_dir / "riplex.log"
+        log_file = tmp_path / "logs" / "riplex.log"
+        log_file.parent.mkdir()
         log_file.write_text("test log content", encoding="utf-8")
 
-        monkeypatch.setattr("tempfile.gettempdir", lambda: str(fake_tmp))
+        monkeypatch.setattr("riplex.snapshot.get_cli_log_path", lambda: log_file)
 
         debug_dir = tmp_path / "_riplex"
         debug_dir.mkdir()
@@ -275,10 +271,21 @@ class TestCopyDebugLog:
         assert result.exists()
         assert result.read_text(encoding="utf-8") == "test log content"
 
+    def test_copies_explicit_source_log(self, tmp_path):
+        log_file = tmp_path / "logs" / "riplex_app.log"
+        log_file.parent.mkdir()
+        log_file.write_text("GUI log content", encoding="utf-8")
+
+        debug_dir = tmp_path / "_riplex"
+        debug_dir.mkdir()
+        result = copy_debug_log(debug_dir, log_file)
+
+        assert result == debug_dir / "riplex.log"
+        assert result.read_text(encoding="utf-8") == "GUI log content"
+
     def test_returns_none_when_no_log(self, tmp_path, monkeypatch):
-        fake_tmp = tmp_path / "empty_tmp"
-        fake_tmp.mkdir()
-        monkeypatch.setattr("tempfile.gettempdir", lambda: str(fake_tmp))
+        log_file = tmp_path / "missing" / "riplex.log"
+        monkeypatch.setattr("riplex.snapshot.get_cli_log_path", lambda: log_file)
 
         debug_dir = tmp_path / "_riplex"
         debug_dir.mkdir()


### PR DESCRIPTION
## Summary

- run unit and offline fixture-driven integration tests on Ubuntu 24.04
- exercise the installed CLI while `/tmp/riplex` is root-owned
- move CLI debug logs to the platform-specific per-user log directory
- preserve the correct CLI or GUI log in debug snapshots
- cover the configurable MakeMKV drive-list timeout wiring

## Linux test scope

The workflow does not access an optical drive, perform a rip, or call TMDb or dvdcompare at runtime. Those boundaries use committed fixtures and test doubles.

## Local verification

- `py -m pytest -q --disable-warnings` (`1327 passed`)
- workflow YAML and required Linux smoke gates parsed successfully
- source and test diagnostics clean

Related to #24.